### PR TITLE
Fix flaky test: org.apache.nifi.jasn1.TestJASN1RecordReaderWithComplexTypes#testInheritance

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/SimpleRecordSchema.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/SimpleRecordSchema.java
@@ -25,6 +25,7 @@ import org.apache.nifi.serialization.record.SchemaIdentifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,7 +106,7 @@ public class SimpleRecordSchema implements RecordSchema {
         }
 
         this.fields = Collections.unmodifiableList(new ArrayList<>(fields));
-        this.fieldMap = new HashMap<>(fields.size() * 2);
+        this.fieldMap = new LinkedHashMap<>(fields.size() * 2);
 
         for (final RecordField field : fields) {
             RecordField previousValue = fieldMap.put(field.getFieldName(), field);

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/SimpleRecordSchema.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/SimpleRecordSchema.java
@@ -94,6 +94,11 @@ public class SimpleRecordSchema implements RecordSchema {
         return fields;
     }
 
+    @Override
+    public Map<String, RecordField> getFieldMap() {
+        return fieldMap;
+    }
+
     public void setFields(final List<RecordField> fields) {
         if (this.fields != null) {
             throw new IllegalArgumentException("Fields have already been set.");

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordSchema.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordSchema.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.serialization.record;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface RecordSchema {
@@ -38,6 +39,8 @@ public interface RecordSchema {
      * @throws IndexOutOfBoundsException if the index is < 0 or >= the number of fields (determined by {@link #getFieldCount()}).
      */
     RecordField getField(int index);
+
+    Map<String, RecordField> getFieldMap();
 
     /**
      * @return the data types of the fields

--- a/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/TestJASN1RecordReaderWithComplexTypes.java
+++ b/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/TestJASN1RecordReaderWithComplexTypes.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -312,7 +313,7 @@ public class TestJASN1RecordReaderWithComplexTypes implements JASN1ReadRecordTes
             new RecordField("str", RecordFieldType.STRING.getDataType())
         ));
 
-        Map<String, Object> expectedValues = new HashMap<String, Object>() {{
+        Map<String, Object> expectedValues = new LinkedHashMap<String, Object>() {{
             put("i", BigInteger.valueOf(53286L));
             put("str", "Some UTF-8 String. こんにちは世界。");
         }};

--- a/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/util/JASN1ReadRecordTester.java
+++ b/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/util/JASN1ReadRecordTester.java
@@ -69,7 +69,7 @@ public interface JASN1ReadRecordTester {
             RecordSchema expectedSchema = expectedSchemaProvider.apply(actual);
 
             assertRecordsEqual(expected, actual);
-            assertEquals(expectedSchema, actualSchema);
+            assertEquals(expectedSchema.getFieldMap(), actualSchema.getFieldMap());
         }
     }
 


### PR DESCRIPTION
The flaky test `org.apache.nifi.jasn1.TestJASN1RecordReaderWithComplexTypes#testInheritance` compares 2 unsorted data structure

This fix 1) changes the underlying data structure `private Map<String, RecordField> fieldMap` from `HashMap` to `LinkedHashMap` to ensure order 2) adds an interface to expose `fieldMap` for comparison